### PR TITLE
deps: build.jl: remove `mkl` and fix broken CI on x64 macOS-latest

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,3 +3,4 @@ using Conda
 Conda.add("ase", channel = "conda-forge")
 Conda.add("rdkit", channel = "conda-forge")
 Conda.add("pymatgen", channel = "conda-forge")
+Conda.rm("mkl")


### PR DESCRIPTION
Remove the `mkl` library using `Conda`, so that GitHub Actions can run,
and changes can also be tested on `x64 macOS-latest`; which was
previously broken and would throw an error
`Intel MKL FATAL ERROR: Cannot load libmkl_intel_thread.1.dylib`.

Signed-off-by: Anant Thazhemadam <anant.thazhemadam@gmail.com>