### PR TITLE
Remove MKL from build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
       - run: |
           julia --project -e '
             using Conda
-            ENV["PATH"] = Conda.bin_dir(Conda.ROOTENV) * ";" * ENV["PATH"]
+            ENV["PATH"] = Conda.bin_dir(Conda.ROOTENV) * \";\" * ENV["PATH"]
           '
       - name: Run Tests
         uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           LD_LIBRARY_PATH: "$HOME/.julia/conda/3/lib"
       - run: |
-          julia -e '
+          julia --project -e '
             using Conda
             ENV["PATH"] = Conda.bin_dir(Conda.ROOTENV) * ";" * ENV["PATH"]
           '

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,10 +41,10 @@ jobs:
         env:
           LD_LIBRARY_PATH: "$HOME/.julia/conda/3/lib"
       - run: |
-          julia -e """
+          julia -e '
             using Conda
             ENV["PATH"] = Conda.bin_dir(Conda.ROOTENV) * ";" * ENV["PATH"]
-          """
+          '
       - name: Run Tests
         uses: julia-actions/julia-runtest@v1
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,11 +40,11 @@ jobs:
         uses: julia-actions/julia-buildpkg@v1
         env:
           LD_LIBRARY_PATH: "$HOME/.julia/conda/3/lib"
-      - run: |
-          julia --project -e '
-            using Conda
-            ENV["PATH"] = Conda.bin_dir(Conda.ROOTENV) * "\;" * ENV["PATH"]
-          '
+      # - run: |
+      #     julia --project -e '
+      #       using Conda
+      #       ENV["PATH"] = Conda.bin_dir(Conda.ROOTENV) * "\;" * ENV["PATH"]
+      #     '
       - name: Run Tests
         uses: julia-actions/julia-runtest@v1
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     env:
       PYTHON: ""
+      LD_LIBRARY_PATH: "$HOME/.julia/conda/3/lib"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
       - run: |
           julia --project -e '
             using Conda
-            ENV["PATH"] = Conda.bin_dir(Conda.ROOTENV) * \";\" * ENV["PATH"]
+            ENV["PATH"] = Conda.bin_dir(Conda.ROOTENV) * "\;" * ENV["PATH"]
           '
       - name: Run Tests
         uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,11 @@ jobs:
             ${{ matrix.os }}-
       - name: Build Package
         uses: julia-actions/julia-buildpkg@v1
+      - run: |
+          julia -e """
+            using Conda
+            ENV["PATH"] = Conda.bin_dir(Conda.ROOTENV) * ";" * ENV["PATH"]
+          """
       - name: Run Tests
         uses: julia-actions/julia-runtest@v1
       - name: Process Coverage

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,5 +3,3 @@ using Conda
 Conda.add("ase", channel = "conda-forge")
 Conda.add("rdkit", channel = "conda-forge")
 Conda.add("pymatgen", channel = "conda-forge")
-Conda.rm("mkl")
-Conda.add("mkl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using Test
 
 const testdir = dirname(@__FILE__)
 
+@show ENV["LD_LIBRARY_PATH"]
+
 tests = [
     "module_tests",
     "utils/ElementFeatureUtils_tests",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,8 @@
+using Conda
+
+# hackaround conda's path woes
+ENV["PATH"] = Conda.bin_dir(Conda.ROOTENV) * ";" * ENV["PATH"]
+
 using ChemistryFeaturization
 using Test
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Conda
 
 # hackaround conda's path woes
 ENV["PATH"] = Conda.bin_dir(Conda.ROOTENV) * ";" * ENV["PATH"]
+ENV["LD_LIBRARY_PATH"] = "$(ENV["HOME"])/.julia/conda/3/lib"
 
 using ChemistryFeaturization
 using Test


### PR DESCRIPTION
cc @thazhemadam 

This aims to get CI on macOS to not rely on the `MKL` Conda hack which makes the build pretty complex.