### PR TITLE
Graph AD for Forces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Xtals = "ede5f01d-793e-4c47-9885-c447d1f18d6d"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 CSV = "0.7, 0.8"
@@ -40,7 +41,9 @@ Xtals = "0.3"
 julia = "1.6"
 
 [extras]
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test"]
+test = ["FiniteDifferences", "Test", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Xtals = "ede5f01d-793e-4c47-9885-c447d1f18d6d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
@@ -37,7 +38,9 @@ LightGraphs = "1"
 NearestNeighbors = "0.4"
 PyCall = "1"
 SimpleWeightedGraphs = "1"
+StaticArrays = "1"
 Xtals = "0.3"
+Zygote = "0.6"
 julia = "1.6"
 
 [extras]

--- a/src/utils/adjoints.jl
+++ b/src/utils/adjoints.jl
@@ -1,5 +1,6 @@
 using Zygote # , ChainRulesCore
 using Zygote: @adjoint
+using StaticArrays
 using LinearAlgebra
 
 @adjoint function Base.Iterators.Zip(is)
@@ -48,4 +49,15 @@ _zero(::Nothing) = nothing
   end
 
   (y,ld), cutoff_pb
+end
+
+Zygote.@nograd Xtals.Charges{Xtals.Frac}
+
+function Zygote.ChainRulesCore.rrule(::Type{SArray{D, T, ND, L}}, x...) where {D, T, ND, L}
+  y = SArray{D, T, ND, L}(x...)
+  function sarray_pb(Δy)
+    Δy = map(t->eltype(x...)(t...), Δy)
+    return NoTangent(), (Δy...,)
+  end
+  return y, sarray_pb
 end

--- a/src/utils/adjoints.jl
+++ b/src/utils/adjoints.jl
@@ -1,0 +1,51 @@
+using Zygote # , ChainRulesCore
+using Zygote: @adjoint
+using LinearAlgebra
+
+@adjoint function Base.Iterators.Zip(is)
+  Zip_pullback(Δ) = (Zygote.unzip(Δ),)
+  return Base.Iterators.Zip(is), Zip_pullback
+end
+
+@adjoint function Pair(a, b)
+  Pair(a, b), Δ -> (Δ, nothing)
+end
+
+@adjoint function Dict(g::Base.Generator)
+  ys, backs = Zygote.unzip([Zygote.pullback(g.f, args) for args in g.iter])
+  Dict(ys...), Δ -> begin
+    ∂d = first(backs)(Δ)[1]
+    d = Dict(ys...)
+    for (k,v) in pairs(d)
+      d[k] = _zero(v)
+    end
+    (merge(d, ∂d), )
+  end
+end
+
+_zero(x) = zero(x)
+_zero(::Nothing) = nothing
+
+@adjoint function _cutoff!(weight_mat, f, ijd,
+                           nb_counts, longest_dists;
+                           max_num_nbr = 12)
+  y, ld = _cutoff!(weight_mat, f, ijd,
+               nb_counts, longest_dists;
+               max_num_nbr = max_num_nbr)
+  function cutoff_pb((Δ,nt))
+    s = size(Δ)
+    Δ = vec(collect(Δ))
+    for (ix, (_,_,d)) in zip(eachindex(Δ), ijd)
+      y_, back_ = Zygote.pullback(f, d)
+      Δ[ix] *= back_(Δ[ix])[1]
+    end
+    (reshape(Δ, s), nothing,
+    collect(zip(fill(nothing, size(Δ,1)),
+                fill(nothing, size(Δ,1)),
+                Δ)),
+    nothing,
+    nothing)
+  end
+
+  (y,ld), cutoff_pb
+end

--- a/src/utils/graph_building.jl
+++ b/src/utils/graph_building.jl
@@ -10,6 +10,7 @@ using Serialization
 using Xtals
 using NearestNeighbors
 #rc[:paths][:crystals] = @__DIR__ # so that Xtals.jl knows where things are
+using Zygote
 
 # options for decay of bond weights with distance...
 # user can of course write their own as well
@@ -107,22 +108,41 @@ function weights_cutoff(is, js, dists; max_num_nbr = 12, dist_decay_func = inver
 
     # iterate over list of tuples to build edge weights...
     # note that neighbor list double counts so we only have to increment one counter per pair
-    weight_mat = zeros(Float32, num_atoms, num_atoms)
-    for (i, j, d) in ijd
-        # if we're under the max OR if it's at the same distance as the previous one
-        if nb_counts[i] < max_num_nbr || isapprox(longest_dists[i], d)
-            weight_mat[i, j] += dist_decay_func(d)
-            longest_dists[i] = d
-            nb_counts[i] += 1
-        end
-    end
+    weight_mat = zeros(Float64, round(Int,num_atoms), round(Int,num_atoms))
+    weight_mat, longest_dists = _cutoff!(weight_mat,
+                                         dist_decay_func,
+                                         ijd,
+                                         nb_counts,
+                                         longest_dists)
 
     # average across diagonal, just in case
     weight_mat = 0.5 .* (weight_mat .+ weight_mat')
 
     # normalize weights
     weight_mat = weight_mat ./ maximum(weight_mat)
+    weight_mat
 end
+
+
+function _cutoff!(weight_mat, f, ijd,
+                  nb_counts, longest_dists; max_num_nbr = 12)
+
+    for (i, j, d) in ijd
+        # FiniteDifferences doesn't like non integers as indices
+        # and is used to test
+        i, j = round.(Int, (i,j))
+
+        # if we're under the max OR if it's at the same distance as the previous one
+        if nb_counts[i] < max_num_nbr || isapprox(longest_dists[i], d)
+            weight_mat[i, j] += f(d)
+            longest_dists[i] = d
+            nb_counts[i] += 1
+        end
+    end
+
+    weight_mat, longest_dists
+end
+
 
 """
 Build graph using neighbors from faces of Voronoi polyedra and weights from areas. Based on the approach from https://github.com/ulissigroup/uncertainty_benchmarking/blob/aabb407807e35b5fd6ad06b14b440609ae09e6ef/BNN/data_pyro.py#L268
@@ -203,5 +223,7 @@ function neighbor_list(crys::Crystal; cutoff_radius::Real = 8.0)
 end
 
 # TODO: graphs from SMILES via OpenSMILES.jl
+
+include("adjoints.jl")
 
 end

--- a/src/utils/graph_building.jl
+++ b/src/utils/graph_building.jl
@@ -123,7 +123,6 @@ function weights_cutoff(is, js, dists; max_num_nbr = 12, dist_decay_func = inver
     weight_mat
 end
 
-
 function _cutoff!(weight_mat, f, ijd,
                   nb_counts, longest_dists; max_num_nbr = 12)
 
@@ -175,6 +174,31 @@ function weights_voronoi(struc)
     weight_mat = weight_mat ./ maximum(weight_mat)
 end
 
+function index_works(crystal::Xtals.Crystal, n_atoms; cutoff_radius = 8.)
+  tree = BruteTree(Cart(crystal.atoms.coords, crystal.box).x)
+
+  is_raw = 13*n_atoms+1:14*n_atoms
+  js_raw = inrange(tree,
+                   Cart(crystal.atoms.coords[is_raw],
+                        crystal.box).x,
+                   cutoff_radius)
+
+  split1 = map(zip(is_raw, js_raw)) do x
+      [
+          p for p in [(x[1], [j for j in js if j != x[1]]...) for js in x[2]] if
+          length(p) == 2
+      ]
+  end
+  ijraw_pairs = [(split1...)...]
+end
+
+index_map(i, n_atoms) = (i - 1) % n_atoms + 1
+
+function more_index_stuff(s, n; cutoff_radius = 8.)
+  ijraw_pairs = index_works(s, n, cutoff_radius = cutoff_radius)
+  [t[1] for t in ijraw_pairs],
+  [t[2] for t in ijraw_pairs]
+end
 
 """
 Find all lists of pairs of atoms in `crys` that are within a distance of `cutoff_radius` of each other, respecting periodic boundary conditions.
@@ -186,7 +210,7 @@ function neighbor_list(crys::Crystal; cutoff_radius::Real = 8.0)
 
     # make 3 x 3 x 3 supercell and find indices of "middle" atoms
     # as well as index mapping from outer -> inner
-    supercell = replicate(crys, (3, 3, 3))
+    supercell = replicate2(crys, (3, 3, 3))
 
     # check for size of cutoff radius relative to size of cell
     min_celldim = min(crys.box.a, crys.box.b, crys.box.c)
@@ -195,35 +219,19 @@ function neighbor_list(crys::Crystal; cutoff_radius::Real = 8.0)
         cutoff_radius = 0.99 * min_celldim
     end
 
-    # todo: try BallTree, also perhaps other leafsize values
-    #tree = BruteTree(sc.atoms.coords.xf, PeriodicEuclidean([1.0, 1.0, 1.0]))
-    tree = BruteTree(Cart(supercell.atoms.coords, supercell.box).x)
-
-    is_raw = 13*n_atoms+1:14*n_atoms
-    js_raw =
-        inrange(tree, Cart(supercell.atoms.coords[is_raw], supercell.box).x, cutoff_radius)
-
-    index_map(i) = (i - 1) % n_atoms + 1 # I suddenly understand why some people dislike 1-based indexing
-
-    # this looks horrifying but it does do the right thing...
-    #ijraw_pairs = [p for p in Iterators.flatten([Iterators.product([p for p in zip(is_raw, js_raw)][n]...) for n in 1:4]) if p[1]!=p[2]]
-    split1 = map(zip(is_raw, js_raw)) do x
-        return [
-            p for p in [(x[1], [j for j in js if j != x[1]]...) for js in x[2]] if
-            length(p) == 2
-        ]
+    is, js = Zygote.ignore() do
+      more_index_stuff(supercell, n_atoms; cutoff_radius = cutoff_radius)
     end
-    ijraw_pairs = [(split1...)...]
-    get_pairdist((i, j)) = distance(supercell.atoms, supercell.box, i, j, false)
-    dists = get_pairdist.(ijraw_pairs)
-    is = index_map.([t[1] for t in ijraw_pairs])
-    js = index_map.([t[2] for t in ijraw_pairs])
 
+    dists = Xtals.distance(supercell.atoms.coords, supercell.box, is, js, false)
+
+    is, js = Int.(index_map.(is, n_atoms)),
+             Int.(index_map.(js, n_atoms))
     return is, js, dists
 end
 
 # TODO: graphs from SMILES via OpenSMILES.jl
 
 include("adjoints.jl")
-
+include("xtals.jl")
 end

--- a/src/utils/xtals.jl
+++ b/src/utils/xtals.jl
@@ -1,0 +1,88 @@
+using StaticArrays
+using Xtals
+using Zygote: @adjoint
+using Zygote.ChainRulesCore
+using NearestNeighbors
+using LinearAlgebra
+
+function rl(f_to_c::Array{Float64, 2})
+   # the unit cell vectors are the columns of f_to_c
+   a₁ = f_to_c[:, 1]
+   a₂ = f_to_c[:, 2]
+   a₃ = f_to_c[:, 3]
+
+   # r = zeros(Float64, 3, 3)
+   l1 = 2 * π * cross(a₂, a₃) / dot(a₁, cross(a₂, a₃))
+   l2 = 2 * π * cross(a₃, a₁) / dot(a₂, cross(a₃, a₁))
+   l3 = 2 * π * cross(a₁, a₂) / dot(a₃, cross(a₁, a₂))
+   vcat(l1', l2', l3')
+end
+
+@adjoint function Xtals.reciprocal_lattice(x)
+  Zygote.pullback(rl, x)
+end
+
+function replicate2(crystal::Crystal, repfactors::Tuple{Int, Int, Int})
+    if Xtals.ne(crystal.bonds) != 0
+        error("the crystal " * crystal.name * " has assigned bonds. to replicate, remove
+        its bonds with `remove_bonds!(crystal)`. then use `infer_bonds(crystal)` to
+        reassign the bonds")
+    end
+
+    assert_P1_symmetry(crystal)
+
+    n_atoms = crystal.atoms.n * prod(repfactors)
+    n_charges = crystal.charges.n * prod(repfactors)
+
+    box = replicate(crystal.box, repfactors)
+
+    charges = Xtals.Charges{Xtals.Frac}(n_charges)
+    # atoms = Xtals.Atoms{Xtals.Frac}(n_atoms)
+
+    xf_shift = Zygote.ignore() do
+      x = repeat(collect.(sort(vec(collect(Iterators.product(0:2, 0:2, 0:2))))), inner = crystal.atoms.n)
+      reduce(hcat, x)
+    end
+
+    xf_raw = repeat(crystal.atoms.coords.xf, 1, prod(repfactors)) .+ xf_shift
+    xf = xf_raw ./ repfactors
+    
+    frac = Frac(xf)
+    species = repeat(crystal.atoms.species, inner = prod(repfactors))
+    atoms = Xtals.Atoms(length(species), species, frac)
+
+    # charge_counter = 0
+    # atom_counter = 0
+    # for ra = 0:(repfactors[1] - 1), rb = 0:(repfactors[2] - 1), rc = 0:(repfactors[3] - 1)
+    #     xf_shift = 1.0 * [ra, rb, rc]
+
+    #     # replicate atoms
+    #     for i = 1:crystal.atoms.n
+    #         atom_counter += 1
+
+    #         atoms.species[atom_counter] = crystal.atoms.species[i]
+
+    #         xf = crystal.atoms.coords.xf[:, i] + xf_shift
+    #         atoms.coords.xf[:, atom_counter] = xf ./ repfactors
+    #     end
+
+    #     # replicate charges
+    #     for i = 1:crystal.charges.n
+    #         charge_counter += 1
+
+    #         charges.q[charge_counter] = crystal.charges.q[i]
+
+    #         xf = crystal.charges.coords.xf[:, i] + xf_shift
+    #         charges.coords.xf[:, charge_counter] = xf ./ repfactors
+    #     end
+    # end
+    # global reggatoms = atoms
+    
+    return Crystal(crystal.name, box, atoms, charges, Xtals.MetaGraph(n_atoms), crystal.symmetry)
+end
+
+function Xtals.distance(coords::Xtals.Frac, box::Xtals.Box, i, j, pbc)
+  dxf = @views coords.xf[:, i] - coords.xf[:, j]
+  norm.(eachcol(box.f_to_c * dxf))
+end
+

--- a/test/featurizations/GraphNodeFeaturization_tests.jl
+++ b/test/featurizations/GraphNodeFeaturization_tests.jl
@@ -81,3 +81,4 @@ using ChemistryFeaturization.Featurization
     end
 
 end
+

--- a/test/utils/GraphBuilding_tests.jl
+++ b/test/utils/GraphBuilding_tests.jl
@@ -1,6 +1,8 @@
 using Test
 using ChemistryFeaturization.Utils.GraphBuilding
 using Xtals
+using Zygote, FiniteDifferences
+
 
 @testset "GraphBuilding" begin
     path1 = abspath(@__DIR__, "..", "test_data", "strucs", "mp-195.cif")
@@ -19,4 +21,28 @@ using Xtals
     adjc, elsc = build_graph(Crystal(path1))
     @test adjc == wm_true
     @test elsc == els_true
+end
+
+@testset "Graph Building AD tests" begin
+
+  function test_fd(i, j, dist)
+      fd = grad(forward_fdm(2,1),
+                (i,j,dist) -> sum(GraphBuilding.weights_cutoff(i,j,dist)),
+                i, j, dist)
+
+      gs = gradient(i, j, dist) do i, j, dist
+          sum(GraphBuilding.weights_cutoff(i, j, dist))
+      end
+
+      @test gs[1] == fill(nothing, length(i))
+      @test gs[2] == fill(nothing, length(j))
+      t = isapprox(gs[3], fd[3])
+      @show t
+      @test t
+  end
+
+  # test with non-overlapping indices
+  test_fd(collect(1:10), collect(1:10), Float64.(collect(1:10)))
+  # test with overlapping indices
+  test_fd(rand(1:10, 100), rand(1:10, 100), rand(100))
 end


### PR DESCRIPTION
ref #111 

x-ref: https://github.com/Chemellia/ChemistryFeaturization.jl/pull/111#issuecomment-922109332

Okay, so we have the following working.

```Julia
julia> using ChemistryFeaturization, Zygote, Xtals

julia> cr_path = normpath(joinpath(pathof(Xtals), "..", "..", "test", "data", "crystals"))
"/Users/dhairyagandhi/.julia/packages/Xtals/Kf4en/test/data/crystals"

julia> using ChemistryFeaturization.Utils.GraphBuilding

julia> c = Crystal(joinpath(cr_path, "IRMOF-1.cif"))
Name: /Users/dhairyagandhi/.julia/packages/Xtals/Kf4en/test/data/crystals/IRMOF-1.cif
Bravais unit cell of a crystal.
	Unit cell angles α = 90.000000 deg. β = 90.000000 deg. γ = 90.000000 deg.
	Unit cell dimensions a = 25.832000 Å. b = 25.832000 Å, c = 25.832000 Å
	Volume of unit cell: 17237.492730 Å³

	# atoms = 424
	# charges = 0
	chemical formula: Dict(:Zn => 4, :H => 12, :O => 13, :C => 24)
	space Group: P1
	symmetry Operations:
		'x, y, z'

julia> gradient(c) do c
         w, s = build_graph2(c)
         sum(w)
       end
((name = nothing, box = (a = -31.83244099108285, b = -31.832440991082862, c = -31.832440991082862, α = -2.1514963693844834e-14, β = -2.8035019022818323e-14, γ = -3.751262522266638e-14, Ω = nothing, f_to_c = nothing, c_to_f = nothing, reciprocal_lattice = nothing), atoms = (n = nothing, species = nothing, coords = (xf = [-4.78645247969116 4.786452479691137 … 51.735173803203864 51.735173803203864; 4.786452479691156 -4.786452479691122 … 77.23782826208793 -77.23782826208932; 4.786452479691155 4.7864524796911665 … -77.23782826208932 77.23782826208792],)), charges = nothing, bonds = nothing, symmetry = nothing),)
```

which are the gradients for the crystal and graph AD 🎉 

Couple of notes:
1. There were a few missing methods in Xtals to calculate distance, I added those https://github.com/SimonEnsemble/Xtals.jl/pull/101 (and also included a copy in the PR)
2. `replicate` is written with a lot of mutation, and I figured we could write a simpler version, so I did. How do we want to handle this? We could propose this change to Xtals.jl (the performance is roughly same, but of course this allocates)
3. I have refactored some of the indexing utilities and removed them from AD to save some time there. It means we can write it in a neater way if desired.
4. How do we want to test this? Do we have some cases in mind?
5. ~I might have messed up the rebase, so I'll have to move this to a different PR.~

Also, we might have some performance on the table if we optimise this further going by the number of allocations.

```julia
julia> @btime gradient($c) do c
         w, s = build_graph(c)
         sum(w)
       end;
  56.376 ms (572641 allocations: 50.27 MiB)
```