### PR TITLE
Flesh out WeaveFeaturization

### DIFF
--- a/src/features/speciesfeature.jl
+++ b/src/features/speciesfeature.jl
@@ -48,6 +48,7 @@ function SpeciesFeatureDescriptor(name::String)
     else
         # TODO: figure out default binning situation for continuous-valued SFD's
         #codec = OneHotOneCold(false, )
+        codec = DirectCodec(1)
     end
     SpeciesFeatureDescriptor{info[:A],typeof(codec)}(
         name,

--- a/src/featurizations/weavefeaturization.jl
+++ b/src/featurizations/weavefeaturization.jl
@@ -6,9 +6,67 @@ using ..ChemistryFeaturization.FeatureDescriptor:
 
 struct WeaveFeaturization <: AbstractFeaturization
     atom_features::Vector{<:AbstractAtomFeatureDescriptor}
+    bond_features::Vector{<:BondFeatureDescriptor}
     pair_features::Vector{<:AbstractPairFeatureDescriptor}
 end
 
-function encodable_elements(fzn::WeaveFeaturization)
-    # TODO: implement me!
+function WeaveFeaturization(default_atom_feature_list = ["symbol",
+                                                         "degree",
+                                                         "implicit_valence",
+                                                         "formal_charge",
+                                                         "radical_electrons",
+                                                         "hybridization",
+                                                         "isaromatic",
+                                                         "total_H_num"],
+                            default_bond_feature_list = ["bondorder", "isaromaticbond", "isringbond"])
+  species_feats = intersect(default_atom_feature_list, Utils.SpeciesFeatureUtils.sfd_names_props)
+  atoms = SpeciesFeatureDescriptor.(species_feats)
+  bonds = BondFeatureDescriptor.(default_bond_feature_list)
+  WeaveFeaturization(atoms, bonds, pairs)
 end
+
+function encodable_elements(fzn::WeaveFeaturization)
+    intersect([encodable_elements(f) for f in fzn.atom_features]...),
+    intersect([encodable_elements(f) for f in fzn.bond_features]...),
+    intersect([encodable_elements(f) for f in fzn.pair_features]...)
+end
+
+# function encode(fzn::GraphNodeFeaturization, ag::AtomGraph)
+#     encoded = reduce(vcat, map((x) -> encode(x, ag), fzn.features))
+#     return encoded
+# end
+
+function atom_features()
+end
+
+# weave_mols = weave_featurize(smiles[Int((b_i-1)*batch_size+1):Int(b_i*batch_size)],
+#                              atom_feature_list = atom_feature_list,
+#                              bond_feature_list = bond_feature_list)
+# y_batch = [Y[Int((b_i-1)*batch_size+1):Int(b_i*batch_size)]]
+# default_atom_feature_list = ["symbol","degree","implicit_valence","formal_charge","radical_electrons","hybridization","aromaticity","total_H_num" ]
+# default_bond_feature_list = ["bond_type","isConjugated","isInring"]
+
+function encode(fzn::WeaveFeaturization, ag::AtomGraph; atom_feature_kwargs = (;),
+                                                       bond_feature_kwargs = (;),
+                                                       pair_feature_kwargs = (;))
+  af = mapreduce(x -> encode(x, ag, atom_feature_kwargs...), vcat, fzn.atom_features) 
+  bf = mapreduce(x -> encode(x, ag, bond_feature_kwargs...), vcat, fzn.bond_features)
+  pf = mapreduce(x -> encode(x, ag, pair_feature_kwargs...), vcat, fzn.pair_features)
+  vcat(af, bf, pf)
+end
+
+# function decode(fzn::GraphNodeFeaturization, encoded::Matrix{<:Real})
+#     num_atoms = size(encoded, 2)
+#     nbins = [output_shape(f) for f in fzn.features]
+#     local decoded = Dict{Integer,Dict{String,Any}}()
+#     for i = 1:num_atoms
+#         #println("atom $i")
+#         chunks = chunk_vec(encoded[:, i], nbins)
+#         decoded[i] = Dict{String,Any}()
+#         for (chunk, f) in zip(chunks, fzn.features)
+#             #println("    $(f.name): $(decode(f, chunk))")
+#             decoded[i][f.name] = decode(f, chunk)
+#         end
+#     end
+#     return decoded
+# end

--- a/src/utils/speciesfeature_utils.jl
+++ b/src/utils/speciesfeature_utils.jl
@@ -71,13 +71,6 @@ const sfd_names_props = Dict(
         :encodable_elements => mg_elements,
         :codec => DirectCodec,
     ),
-    "total_H_num" => Dict(
-        :A => GraphMol,
-        :compute_f => hydrogenconnected,
-        :categorical => false,
-        :encodable_elements => mg_elements,
-        :codec => DirectCodec,
-    ),
 )
 
 end

--- a/src/utils/speciesfeature_utils.jl
+++ b/src/utils/speciesfeature_utils.jl
@@ -71,6 +71,13 @@ const sfd_names_props = Dict(
         :encodable_elements => mg_elements,
         :codec => DirectCodec,
     ),
+    "charge" => Dict(
+        :A => GraphMol,
+        :compute_f => charge,
+        :categorical => false,
+        :encodable_elements => mg_elements,
+        :codec => DirectCodec,
+    ),
 )
 
 end

--- a/src/utils/speciesfeature_utils.jl
+++ b/src/utils/speciesfeature_utils.jl
@@ -50,6 +50,34 @@ const sfd_names_props = Dict(
         :encodable_elements => mg_elements,
         :possible_vals => [0, 1, 2], # also not certain this is correct
     ),
+    "degree" => Dict(
+        :A => GraphMol,
+        :compute_f => nodedegree,
+        :categorical => false,
+        :encodable_elements => mg_elements,
+        :codec => DirectCodec,
+    ),
+    "radical_electrons" => Dict(
+        :A => GraphMol,
+        :compute_f => multiplicity,
+        :categorical => true,
+        :encodable_elements => mg_elements,
+        :possible_vals => [1, 2, 3],
+    ),
+    "implicit_valence" => Dict(
+        :A => GraphMol,
+        :compute_f => implicithconnected,
+        :categorical => false,
+        :encodable_elements => mg_elements,
+        :codec => DirectCodec,
+    ),
+    "total_H_num" => Dict(
+        :A => GraphMol,
+        :compute_f => hydrogenconnected,
+        :categorical => false,
+        :encodable_elements => mg_elements,
+        :codec => DirectCodec,
+    ),
 )
 
 end


### PR DESCRIPTION
This is based on the weve featurization from the other weave implementation as well as the tests from the ChemistryFeaturization.

I'm not sure I love the way we map from species feature names to the MolecularGraph functions here, seems like that would make it very manual to "just" use some feature provided by MolecularGraph.

There are still a couple of TODOs, one of them being fleshing out both `atom_features` as well as `pair_features`, but before I implement them, I wanted to ask whether we would be fine with something like a `FeaturizedMol` (similar to `FeaturizedAtom`, it can hold featurized atom, bond and pair info), or is there a different method I should look into?